### PR TITLE
fix: 🐛 timeout between init and log call

### DIFF
--- a/notebooks/tensorflow/tuto/weights-and-biases/notebook_Weights_and_Biases_MNIST.ipynb
+++ b/notebooks/tensorflow/tuto/weights-and-biases/notebook_Weights_and_Biases_MNIST.ipynb
@@ -354,7 +354,7 @@
     "                 })\n",
     "\n",
     "# use this to configure our experiment\n",
-    "config = wandb.config\n",
+    "config = run.config\n",
     "\n",
     "# initialize model\n",
     "tf.keras.backend.clear_session()\n",
@@ -563,7 +563,7 @@
     "print('Test error rate: ', round((1 - accuracy) * 100, 2))\n",
     "\n",
     "# with wandb.log you can pass in metrics as key-value pairs\n",
-    "wandb.log({'Test error rate': round((1 - accuracy) * 100, 2)})\n",
+    "run.log({'Test error rate': round((1 - accuracy) * 100, 2)})\n",
     "\n",
     "run.join()"
    ]


### PR DESCRIPTION
@eleapttn suite à mes échanges avec Wandb (voir https://github.com/wandb/client/issues/3512), je te propose cette correction.

Il faudra peut être repasser sur d'autres Notebooks