### PR TITLE
feat: 📂 uniformise path for data directories

### DIFF
--- a/notebooks/audio/audio-classification/notebook-marine-sound-classification.ipynb
+++ b/notebooks/audio/audio-classification/notebook-marine-sound-classification.ipynb
@@ -480,7 +480,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file = open(\"data.csv\", \"w\", newline = \"\")\n",
+    "file = open(\"/workspace/data/data.csv\", \"w\", newline = \"\")\n",
     "with file:\n",
     "    writer = csv.writer(file)\n",
     "    writer.writerow(header)"
@@ -543,7 +543,7 @@
     "            to_append += f' {np.mean(e)}'\n",
     "\n",
     "        to_append += f' {animal}'\n",
-    "        file = open('data.csv', 'a', newline = '')\n",
+    "        file = open('/workspace/data/data.csv', 'a', newline = '')\n",
     "\n",
     "        with file:\n",
     "            writer = csv.writer(file)\n",
@@ -777,7 +777,7 @@
     }
    ],
    "source": [
-    "df = pd.read_csv('data.csv')\n",
+    "df = pd.read_csv('/workspace/data/data.csv')\n",
     "df.head()"
    ]
   },
@@ -1394,7 +1394,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file = open('data_test.csv', 'w', newline = '')\n",
+    "file = open('/workspace/data/data_test.csv', 'w', newline = '')\n",
     "with file:\n",
     "    writer = csv.writer(file)\n",
     "    writer.writerow(header_test)"
@@ -1413,8 +1413,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for filename in os.listdir(f\"/workspace/data_test/\"):\n",
-    "    sound_name = f\"/workspace/data_test/{filename}\"\n",
+    "for filename in os.listdir(f\"/workspace/data/data_test/\"):\n",
+    "    sound_name = f\"/workspace/data/data_test/{filename}\"\n",
     "    y, sr = librosa.load(sound_name, mono = True, duration = 30)\n",
     "    chroma_stft = librosa.feature.chroma_stft(y = y, sr = sr)\n",
     "    rmse = librosa.feature.rms(y = y)\n",
@@ -1428,7 +1428,7 @@
     "    for e in mfcc:\n",
     "        to_append += f' {np.mean(e)}'\n",
     "\n",
-    "    file = open('data_test.csv', 'a', newline = '')\n",
+    "    file = open('/workspace/data/data_test.csv', 'a', newline = '')\n",
     "\n",
     "    with file:\n",
     "        writer = csv.writer(file)\n",
@@ -1575,7 +1575,7 @@
     }
    ],
    "source": [
-    "df_test = pd.read_csv('data_test.csv')\n",
+    "df_test = pd.read_csv('/workspace/data/data_test.csv')\n",
     "df_test.head()"
    ]
   },


### PR DESCRIPTION
Goal: some path for the data are absolute without folder name (for example data.csv) so these files are created in the ai-training-example folder.

I think it's better to uniformise that all data are stored in the data folder 😉 