### PR TITLE
fix: Update notebook-introduction-linear-regression.ipynb

### DIFF
--- a/notebooks/getting-started/miniconda/ai-notebooks-introduction/notebook-introduction-linear-regression.ipynb
+++ b/notebooks/getting-started/miniconda/ai-notebooks-introduction/notebook-introduction-linear-regression.ipynb
@@ -47,7 +47,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install pandas matplotlib sklearn numpy"
+    "!pip install --upgrade pip\n",
+    "!pip install pandas matplotlib scikit-learn numpy"
    ]
   },
   {
@@ -91,7 +92,7 @@
    "outputs": [],
    "source": [
     "# convert csv file into dataframe\n",
-    "df = pd.read_csv('/workspace/ai-training-examples/notebooks/miniconda/ai-notebooks-introduction/student_scores.csv')"
+    "df = pd.read_csv('student_scores.csv')"
    ]
   },
   {
@@ -626,8 +627,8 @@
    ],
    "source": [
     "new_prediction = model.predict(X_test)\n",
-    "print(\"Student n°1, theorical result:\", round(float(new_prediction[0]), 2), \"%\")\n",
-    "print(\"Student n°2, theorical result:\", round(float(new_prediction[1]), 2), \"%\")"
+    "print(\"Student n°1, theorical result:\", round(float(new_prediction[0][0]), 2), \"%\")\n",
+    "print(\"Student n°2, theorical result:\", round(float(new_prediction[1][0]), 2), \"%\")"
    ]
   },
   {


### PR DESCRIPTION
I was testing this notebook on Miniconda- conda-py311-cudaDevel11.8 and got some errors,
here are the fix I had to make to make the notebook ends without error.

- updated scikit-learn package name, previous was deprecated 
- fixed csv path
- fixed error on numpy array conversion